### PR TITLE
Vim changes. Terminal below text, and cmd-c/v/z/a keys.

### DIFF
--- a/dotfiles/vim/.vimrc
+++ b/dotfiles/vim/.vimrc
@@ -3,6 +3,7 @@
 "" 19 juni 2022 08:38 - Testing editor splits and project drawer stuff
 "" sep. 23 12:59:24 2022 - Disabling visual mode on mouse select for vim
 "" okt.  2 10:22:24 2022 - Enabling relative line numbers
+"" 14 Apr 18:48:57 2023 - Setting splitbelow to have terminals open on bottom
 
 let g:netrw_banner = 0
 let g:netrw_liststyle = 3
@@ -19,4 +20,6 @@ set mouse-=a
 
 set number
 set relativenumber
+
+set splitbelow
 

--- a/dotfiles/vim/.vimrc
+++ b/dotfiles/vim/.vimrc
@@ -4,6 +4,14 @@
 "" sep. 23 12:59:24 2022 - Disabling visual mode on mouse select for vim
 "" okt.  2 10:22:24 2022 - Enabling relative line numbers
 "" 14 Apr 18:48:57 2023 - Setting splitbelow to have terminals open on bottom
+"" 19 Apr 10:18 2023 - Load defaults.vim and mswin.vim
+
+"" Sane defaults
+source $VIMRUNTIME/defaults.vim
+
+"" CUA Mode, I cannot live without it
+source $VIMRUNTIME/mswin.vim
+set keymodel-=stopsel
 
 let g:netrw_banner = 0
 let g:netrw_liststyle = 3


### PR DESCRIPTION
In MacOS, I am way to used to the normal cmd-c/v/z/a keys for copying
and pasting text. This makes it hard to use MacVim and GVIM to a large
extend. Therefore I am enabling the mswin plugin which allows this.

When I open terminals in vim I want them to open on the bottom, just
like in VSCode.
