### PR TITLE
Emacs 26 seems to need package-initialize for evil.

### DIFF
--- a/dotfiles/emacs/.emacs
+++ b/dotfiles/emacs/.emacs
@@ -18,6 +18,15 @@
 ;; John Grundback, Los Angeles, January 16 2022
 ;;
 
+;;
+;; 18 Jun 2023, 18:54 - Added by Emacs 26 to get evil working
+;;
+;; Added by Package.el.  This must come before configurations of
+;; installed packages.  Don't delete this line.  If you don't want it,
+;; just comment it out by adding a semicolon to the start of the line.
+;; You may delete these explanatory comments.
+(package-initialize)
+
 ;;Goto line
 (global-set-key (quote [f12]) (quote goto-line))
 
@@ -103,7 +112,7 @@
 ;;
 
 ;; prevent silly initial splash screen
-(setq inhibit-splash-screen t)
+; (setq inhibit-splash-screen t)
 
 (cond ((window-system)
 ;; (cond ((display-graphic-p)


### PR DESCRIPTION
When testing evil in Emacs 26, evil did not seem to work until (package-initialize) was added to init. Actually this was automatically added by Package.el, after which evil started working again.